### PR TITLE
Package project for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+dist/
+build/
+.venv/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,16 +4,16 @@ FROM python:3.11-slim
 # Create app directory
 WORKDIR /app
 
-# Install dependencies
-COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
-
-# Copy the rest of the application code
+# Copy project metadata and source
+COPY pyproject.toml README.md MANIFEST.in ./
 COPY bot.py ./
+
+# Install the packaged application
+RUN pip install --no-cache-dir .
 
 # Provide a non-root user for better security
 RUN useradd --create-home bot && chown -R bot:bot /app
 USER bot
 
-# Run the bot
-CMD ["python", "bot.py"]
+# Run the bot via the console script entrypoint
+CMD ["invite-role-bot"]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.md

--- a/README.md
+++ b/README.md
@@ -52,6 +52,35 @@ Roles are assigned automatically when new members join using a tracked invite.
 
 ## Development without Docker
 
-If you prefer to run the bot locally, create a Python virtual environment,
-install dependencies from `requirements.txt`, set `DISCORD_TOKEN`, and start
-`python bot.py`.
+If you prefer to run the bot locally, create a Python virtual environment and
+install the package in editable mode:
+
+```bash
+python -m venv .venv
+source .venv/bin/activate  # On Windows use .venv\\Scripts\\Activate.ps1
+pip install --editable .
+```
+
+Set `DISCORD_TOKEN` in your shell and start the console entry point that the
+package exposes:
+
+```bash
+export DISCORD_TOKEN="<your token>"
+invite-role-bot
+```
+
+The legacy workflow of installing from `requirements.txt` and running
+`python bot.py` still works if you prefer not to install the package.
+
+## Building distributable artifacts
+
+To produce a wheel and source distribution, install the `build` tool and run
+
+```bash
+python -m pip install --upgrade build
+python -m build
+```
+
+The resulting artifacts are placed in the `dist/` directory. They can be copied
+to another machine and installed with `pip install <artifact>` to reproduce a
+ready-to-run bot without cloning the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sparke-discord-invite-role-bot"
+version = "0.1.0"
+description = "Discord bot that grants server roles based on invite links."
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [
+    { name = "Sparke Contributors" }
+]
+dependencies = [
+    "discord.py>=2.3.2,<3.0.0"
+]
+keywords = ["discord", "bot", "automation", "invites"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Operating System :: OS Independent",
+]
+
+[project.scripts]
+invite-role-bot = "bot:main"
+
+[tool.setuptools]
+py-modules = ["bot"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-discord.py==2.3.2
+discord.py>=2.3.2,<3.0.0


### PR DESCRIPTION
## Summary
- add a `pyproject.toml` and MANIFEST to package the bot with a console entry point
- update the Docker image to install the packaged project and run the new script
- document editable installs and distribution build steps for local workflows

## Testing
- python -m build

------
https://chatgpt.com/codex/tasks/task_e_68cddb70b2a883228074bcc8a992c1b1